### PR TITLE
Improve README syntax

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -96,7 +96,7 @@ c2gFngOSVOrxJswb8/BUkA==
 
 === Arbitrary queries
 
-When above two methods are not flexible enough, a +\#query+ method can be
+When above two methods are not flexible enough, a +#query+ method can be
 called.  It returns an instance of +Faraday::Response+.  All the arguments
 become query string parameters (with exception of +keyserver+, which is
 described in the next section).
@@ -113,7 +113,7 @@ HkpClient.query(op: "vindex", search: "linus@example.com", options: "mr")
 
 === Using custom keyserver
 
-A +keyserver+ option can be passed to either +\#search+, +\#get+, or +\#query+
+A +keyserver+ option can be passed to either +#search+, +#get+, or +#query+
 method.  Accepted URI schemes are +http+, +https+, +hkp+, and +hkps+.
 
 TODO: Easy support for custom certificates.

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,4 @@
-HKP Client
-==========
+= HKP Client
 
 image:https://img.shields.io/gem/v/hkp_client.svg["Gem Version", link="https://rubygems.org/gems/hkp_client"]
 image:https://img.shields.io/travis/riboseinc/hkp_client/master.svg["Build Status", link="https://travis-ci.org/riboseinc/hkp_client"]
@@ -15,11 +14,9 @@ submitting keys to keyserver.
 NOTE: This gem registers +hkp+, and +hkps+ URI schemes (adds them to
 +URI.scheme_list+).
 
-Usage
------
+== Usage
 
-Searching
-~~~~~~~~~
+=== Searching
 
 Searching by some criteria.  Returns search results as an array of arrays.
 
@@ -68,8 +65,7 @@ casting (e.g. timestamps and numbers).
 Search results may include expired keys.  If that's unwanted, these keys must
 be filtered out by user.
 
-Fetching keys
-~~~~~~~~~~~~~
+=== Fetching keys
 
 Operation returns the ASCII-armored keyring as defined in
 https://tools.ietf.org/html/rfc2440#section-11.1[RFC 2440, section 11.1],
@@ -98,8 +94,7 @@ c2gFngOSVOrxJswb8/BUkA==
 -----END PGP PUBLIC KEY BLOCK-----
 --------------------------------------------------------------------------------
 
-Arbitrary queries
-~~~~~~~~~~~~~~~~~
+=== Arbitrary queries
 
 When above two methods are not flexible enough, a +\#query+ method can be
 called.  It returns an instance of +Faraday::Response+.  All the arguments
@@ -116,8 +111,7 @@ is used, typically HTML.
 HkpClient.query(op: "vindex", search: "linus@example.com", options: "mr")
 --------------------------------------------------------------------------------
 
-Using custom keyserver
-~~~~~~~~~~~~~~~~~~~~~~
+=== Using custom keyserver
 
 A +keyserver+ option can be passed to either +\#search+, +\#get+, or +\#query+
 method.  Accepted URI schemes are +http+, +https+, +hkp+, and +hkps+.
@@ -129,8 +123,7 @@ TODO: Easy support for custom certificates.
 HkpClient.get "linus@example.com", keyserver: "hkp://server.you.want:8888"
 --------------------------------------------------------------------------------
 
-Contributing
-------------
+== Contributing
 
 First, thank you for contributing!  We love pull requests from everyone.
 By participating in this project, you hereby grant Ribose Inc. the right to
@@ -147,20 +140,17 @@ Here are a few technical guidelines to follow:
     Rubocop, also Hound CI will report any offences when you open a pull
     request).
 
-Credits
--------
+== Credits
 
 This gem is developed, maintained and funded by
 https://www.ribose.com[Ribose Inc].
 
-License
--------
+== License
 
 The gem is available as open source under the terms of the
 https://opensource.org/licenses/MIT[MIT License].
 
-Resources
----------
+== Resources
 
 - https://tools.ietf.org/html/draft-shaw-openpgp-hkp-00[HKP protocol definition (IETF draft)]
 - http://www.mit.edu/afs/net.mit.edu/project/pks/thesis/paper/thesis.html[A PGP Public Key Server thesis]

--- a/README.adoc
+++ b/README.adoc
@@ -11,8 +11,8 @@ HKP Client is a minimalist HKP (OpenPGP HTTP Keyserver Protocol) client, which
 queries PGP public keyservers, and downloads public keys.  It does not support
 submitting keys to keyserver.
 
-NOTE: This gem registers +hkp+, and +hkps+ URI schemes (adds them to
-+URI.scheme_list+).
+NOTE: This gem registers `hkp`, and `hkps` URI schemes (adds them to
+`URI.scheme_list`).
 
 == Usage
 
@@ -20,7 +20,7 @@ NOTE: This gem registers +hkp+, and +hkps+ URI schemes (adds them to
 
 Searching by some criteria.  Returns search results as an array of arrays.
 
-For exact searches, an +exact+ option can be set to true.  The meaning of
+For exact searches, an `exact` option can be set to true.  The meaning of
 "exact" is not defined by standard, and may be ignored by servers.
 
 [source,lang=ruby]
@@ -69,7 +69,7 @@ be filtered out by user.
 
 Operation returns the ASCII-armored keyring as defined in
 https://tools.ietf.org/html/rfc2440#section-11.1[RFC 2440, section 11.1],
-or +nil+.
+or `nil`.
 
 For example, executing following snippet:
 
@@ -96,13 +96,13 @@ c2gFngOSVOrxJswb8/BUkA==
 
 === Arbitrary queries
 
-When above two methods are not flexible enough, a +#query+ method can be
-called.  It returns an instance of +Faraday::Response+.  All the arguments
-become query string parameters (with exception of +keyserver+, which is
+When above two methods are not flexible enough, a `#query` method can be
+called.  It returns an instance of `Faraday::Response`.  All the arguments
+become query string parameters (with exception of `keyserver`, which is
 described in the next section).
 
-For example, a following snippet performs a +vindex+ operation for
-+linus@example.com+ query.  The +mr+ option specifies that search results should
+For example, a following snippet performs a `vindex` operation for
+`linus@example.com` query.  The `mr` option specifies that search results should
 be presented in a machine-readable format.  By default, a human-readable format
 is used, typically HTML.
 
@@ -113,8 +113,8 @@ HkpClient.query(op: "vindex", search: "linus@example.com", options: "mr")
 
 === Using custom keyserver
 
-A +keyserver+ option can be passed to either +#search+, +#get+, or +#query+
-method.  Accepted URI schemes are +http+, +https+, +hkp+, and +hkps+.
+A `keyserver` option can be passed to either `#search`, `#get`, or `#query`
+method.  Accepted URI schemes are `http`, `https`, `hkp`, and `hkps`.
 
 TODO: Easy support for custom certificates.
 

--- a/README.adoc
+++ b/README.adoc
@@ -20,10 +20,12 @@ NOTE: This gem registers `hkp`, and `hkps` URI schemes (adds them to
 
 Searching by some criteria.  Returns search results as an array of arrays.
 
+The search term does not have to be an e-mail address, but that's 
+
 For exact searches, an `exact` option can be set to true.  The meaning of
 "exact" is not defined by standard, and may be ignored by servers.
 
-[source,lang=ruby]
+[source,ruby]
 --------------------------------------------------------------------------------
 HkpClient.search "linus@example.com"
 HkpClient.search "linus@example.com", exact: true
@@ -32,7 +34,7 @@ HkpClient.search "linus@example.com", exact: true
 Search operations returns an array of hashes.  In this case, it is a one-element
 array:
 
-[source,lang=ruby]
+[source,ruby]
 --------------------------------------------------------------------------------
 [
   {
@@ -73,7 +75,7 @@ or `nil`.
 
 For example, executing following snippet:
 
-[source,lang=ruby]
+[source,ruby]
 --------------------------------------------------------------------------------
 HkpClient.get "linus@example.com"
 --------------------------------------------------------------------------------
@@ -106,7 +108,7 @@ For example, a following snippet performs a `vindex` operation for
 be presented in a machine-readable format.  By default, a human-readable format
 is used, typically HTML.
 
-[source,lang=ruby]
+[source,ruby]
 --------------------------------------------------------------------------------
 HkpClient.query(op: "vindex", search: "linus@example.com", options: "mr")
 --------------------------------------------------------------------------------
@@ -118,7 +120,7 @@ method.  Accepted URI schemes are `http`, `https`, `hkp`, and `hkps`.
 
 TODO: Easy support for custom certificates.
 
-[source,lang=ruby]
+[source,ruby]
 --------------------------------------------------------------------------------
 HkpClient.get "linus@example.com", keyserver: "hkp://server.you.want:8888"
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Various small tweaks in README

1. Use different section headers syntax (fixes #10)
2. Remove unnecessary and broken backslash escaping
3. Use backticks instead of plus sings, for surrounding inlined code pieces
4. Fix annotations at listing blocks